### PR TITLE
Update upgrade.rst

### DIFF
--- a/doc/source/upgrade.rst
+++ b/doc/source/upgrade.rst
@@ -30,6 +30,9 @@ If you installed using setup.py
 
             git pull
 
-    #. Reinstall
+    #. Go into your miseqpipeline directory and rerun the setup script
 
-        Then follow :ref:`install <install-system-packages>`
+        .. code-block:: bash
+
+          python setup.py install
+


### PR DESCRIPTION
Rather than run through compete reinstall - they can just run the setup.py inside the miseqpipeline directory - yes?
