### PR TITLE
handling insertions

### DIFF
--- a/devscripts/mpilestat.py
+++ b/devscripts/mpilestat.py
@@ -6,12 +6,12 @@ import pprint
 
 # ngs_mapper should be first in the PATH
 sys.path.insert( 0, os.environ['PATH'].split( ':' )[0] )
-import samtools
+from ngs_mapper import samtools
 
 def main( args ):
     for col in cols( args.bamfile, args.regionstr, args.minmq, args.minbq ):
         stats = col.base_stats()
-        print "{}:".format(col.pos)
+        print "{0}:".format(col.pos)
         pprint.pprint(stats)
 
 def cols( bamfile, regionstr, *args, **kwargs ):

--- a/devscripts/mpilestat.py
+++ b/devscripts/mpilestat.py
@@ -3,7 +3,7 @@
 import sys
 import os
 import pprint
-#ignore
+#ignore again
 # ngs_mapper should be first in the PATH
 sys.path.insert( 0, os.environ['PATH'].split( ':' )[0] )
 from ngs_mapper import samtools

--- a/devscripts/mpilestat.py
+++ b/devscripts/mpilestat.py
@@ -3,7 +3,7 @@
 import sys
 import os
 import pprint
-
+#ignore
 # ngs_mapper should be first in the PATH
 sys.path.insert( 0, os.environ['PATH'].split( ':' )[0] )
 from ngs_mapper import samtools

--- a/ngs_mapper/base_caller.py
+++ b/ngs_mapper/base_caller.py
@@ -613,8 +613,8 @@ def caller(stats2, minbq, maxd, mind=10, minth=0.8):
     base position('refname':N-N). The base is determined by first labeling all bases less than minbq as N and then
     determining if the depth is < mind or >= mind.
     
-    If < and the % of N is > minth then call it an N as it is the majority.
-    If >= 10 then remove all N
+    If < mind and the % of N is > minth then call it an N as it is the majority.
+    If >= mind then remove all N
 
     The final stage is to call call_on_pct with the remaining statistics
 

--- a/ngs_mapper/samtools.py
+++ b/ngs_mapper/samtools.py
@@ -302,10 +302,11 @@ class MPileupColumn(object):
                 n_str = ''.join(takewhile(str.isdigit, self._bases[i+1:]))
                 i += len(n_str) + 1
                 if n_str: #this skips solo hyphens
-                     n = int(n_str)
-                     if x == '+': # deletion
-                         cleaned.append(self._bases[i:i+n])
-                     i += n
+                    n = int(n_str)
+                    if x == '+': # insertion
+                        # Grab [atgcn]+[0-9]+[atgcn]+
+                        cleaned.append(self._bases[i+len(n_str):i+n])
+                    i += n
         return cleaned
 
     @property

--- a/ngs_mapper/samtools.py
+++ b/ngs_mapper/samtools.py
@@ -194,7 +194,6 @@ def char_to_qual( qual_char ):
     '''
     return ord( qual_char ) - 33
 
-
 def get_base_list(bases, refbase ):
     '''
         Returns the bases with the inserts, deletions, $ and ^qual removed.
@@ -260,6 +259,21 @@ def get_base_list(bases, refbase ):
                     cleaned.append(x+bases[i:i+n])
                 i += n
     return cleaned
+
+def fix_gaps(base_list):
+    # read of form +3AAA$ is probably possible.
+    #from itertools import izip_longest
+    #map ifilter(None, izip_longest( zip(*bases[::-1])
+    #import itertools
+    #itertools.izip_longest
+    strip_d = lambda x: x.strip('$')
+    longest_insert = max(imap(len, imap(strip_d, base_list)))
+    is_end = lambda x: x.endswith('$')
+    gap_fill = lambda s: s + (longest_insert - len(s))*'-'
+    return [gap_fill(s) if (not is_end(s)) else strip_d(s) for s  in base_list ]
+
+compose = lambda f, g: lambda *x: f(g(*x))
+get_gapped_bases = compose(fix_gaps, get_base_list)
 class MPileupColumn(object):
     '''
     Represents a single Mpileup column
@@ -303,17 +317,6 @@ class MPileupColumn(object):
         self.__dict__['pos'] = int(value)
 
 
-    def fix_gaps(base_list):
-        # read of form +3AAA$ is probably possible.
-        #from itertools import izip_longest
-        #map ifilter(None, izip_longest( zip(*bases[::-1])
-        #import itertools
-        #itertools.izip_longest
-        strip_d = lambda x: x.strip('$')
-        longest_insert = max(imap(len, imap(strip_d, base_list)))
-        is_end = lambda x: x.endswith('$')
-        gap_fill = lambda s: s + (longest_insert - len(s))*'-'
-        return [gap_fill(s) if (not is_end(s)) else strip_d(s) for s  in base_list ]
 
 
     @property

--- a/ngs_mapper/tests/test_base_caller.py
+++ b/ngs_mapper/tests/test_base_caller.py
@@ -22,7 +22,7 @@ class Base( common.BaseBaseCaller ):
     def mock_mpileup_factory(self, **kwargs):
         '''
         Returns a function that can mock out ngs_mapper.samtools.mpileup
-        
+
         pileupstart - start of the pileup that will be generated
         pileupend - end of the pileup that will be generated
         refdepth - depth of each reference base
@@ -70,7 +70,7 @@ class Base( common.BaseBaseCaller ):
         # Reset to 0
         for k in nonbasekeys:
             stats[k] = 0
-        
+
         # Sum everything
         for k,v in stats.items():
             if k not in nonbasekeys:
@@ -172,7 +172,7 @@ class TestUnitBiasHQ(StatsBase):
             if k not in ('depth','mqualsum','bqualsum'):
                 ebaseq = v['baseq']*int(bias)
                 rbaseq = r[k]['baseq']
-                eq_(ebaseq, r[k]['baseq'], 
+                eq_(ebaseq, r[k]['baseq'],
                     "Len of base {0} should be {1} but got {2}".format(k, len(ebaseq), len(rbaseq))
                )
         # Verify depth is updated
@@ -464,14 +464,14 @@ class TestUnitBlankVcfRows(Base):
         r = self._C('ref', 'A'*10, 0, 3)
         eq_(1, r[0].POS)
         eq_(2, r[1].POS)
-    
+
     def test_gap_middle(self):
         # Should return 4 & 5
         r = self._C('ref', 'A'*10, 3, 6)
         eq_(4, r[0].POS)
         eq_(5, r[1].POS)
-    
-    def test_gap_end(self): 
+
+    def test_gap_end(self):
         r = self._C('ref', 'A'*10, 9, 11)
         eq_(10, r[0].POS)
 
@@ -572,7 +572,7 @@ class TestUnitGenerateVcfRow(MpileBase):
         }
         stats = self.make_stats(base_stats)
         self.setup_mpileupcol(mpilecol, stats=stats)
-    
+
         # Ensure Reference is called
         r = self._C(mpilecol, 'C', 25, 1000, 10, 0.8, 50, 10)
         eq_('C', r.INFO['CB'])
@@ -1009,7 +1009,7 @@ class BaseInty(Base):
         info = dict(info)
         return {
             'CHROM':ref,
-            'POS':pos, 
+            'POS':pos,
             'ID': id,
             'REF': refbase,
             'ALT': altbase,
@@ -1118,7 +1118,8 @@ class TestGenerateVCF(BaseInty):
         # Run the base caller
         # Set bias to 10. Will probably be what will be used as default eventually
         out_vcf = self._C(bam, ref, 'Den1/U88535_1/WestPac/1997/Den1_1:1-15000', out_vcf, 25, 100000, 10, 0.8, 50, 10)
-
+        #TODO: problem is POS 2018
+       #file, vcf_output_file, regionstr=None, minbq=25, maxd=100000, mind=10, minth=0.8, biasth=50, bias=2, threads=1 ):
         # Compare the expected and result vcf
         for evcf, rvcf in self._iter_two_vcf(vcf, out_vcf):
             ecb = evcf['INFO']['CB']
@@ -1223,7 +1224,7 @@ class TestGenerateVcfMultithreaded(BaseInty):
             # Parse out call info
             regionstr = callargs[2]
             tmpfile = callargs[3]
-            
+
             # Every process call gets a new tempfile
             eq_('out.vcf.{0}'.format(i), tmpfile)
             eq_(eregion, regionstr)
@@ -1246,7 +1247,7 @@ class TestUnitMain(BaseInty):
             biasth=biasth,
             bias=bias,
             threads=threads
-       )        
+       )
         with patch('ngs_mapper.base_caller.parse_args') as margparse:
             margparse.return_value = args
             return main()
@@ -1400,3 +1401,26 @@ class TestIntegrate(BaseInty):
             assert o==''
 
         assert not self.cmp_vcf(self.vcf, out_vcf)
+
+#class TestInsertions(unittest.TestCase):
+#
+#    line = 'KC807175.1_Houston	284	N	297	T+1At+1aT+1AT+1AT+1AT+1At+1aT+1AT+1At+1at+1at+1aT$T$T$T$t$t$t$T+1AT+1AT$t+1at+1at$T+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1At+1aT+1AT+1AT+1AT+1At+1at+1aT+1At+1aT+1AT+1AT+1AT+1AT+1At+1at+1aT+1AT+1AT+1AT+1AT+1At+1aT+1AT+1ATT+1AT+1AT+1AT+1AT+1AT+1At+1at+1aT+1AT+1ATT+1AT+1AT+1AtT+1AT+1AT+1AT+1AT+1AT$T+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1At+1aT+1At+1aT+1AT+1At+1aT+1At+1at+1aT+1At+1at+1at+1aT+1AT$T+1At+1aT+1AT+1AT+1AT+1AT+1AT+1AT+1At+1aT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT$T+1AT+1AT+1AT+1AT+1AT$T+1AT+1AT+1At+1at+1at+1at+1at+1at$t+1at+1at$t+1aT+1AT+1At+1at+1at+1at+1at+1aT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1AT+1At+1at+1at+1at+1at+1at+1at+1aT+1AT$T+1At+1at$T+1At+1at+1aT+1At+1aT+1AT+1AT+1At+1aT+1AT+1AT+1At+1at+1aT+1At+1aT+1AT+1At+1aT+1AT+1AT+1AT+1AT+1AT+1AT+1At+1aT+1AT+1AT+1At+1at+1at+1aT+1AT+1AT+1At+1aT+1AT+1At+1at+1at+1aT+1At+1aT+1AT+1At+1aT+1AT+1At+1aT+1AT+1AT+1AT+1AT+1At+1aT+1AT+1AT+1AT+1AT+1At+1aT+1AT+1AT+1AT+1At+1at+1aT+1AT+1At+1at+1at+1aT+1At+1aT$T+1At+1at+1aT+1AT+1At+1aT+1AT+1AT+1AT+1At+1aT+1AT+1At+1aT+1At+1aT+1AT+1At+1aT+1AT+1AT+1At+1at+1aT+1AT+1AT+1At+1at+1aT+1At+1aT+1AT+1AT+1At+1aT+1At+1a^]A	6GCG?GGE4GCG?GGFCCCGGDGGCG2FGGCFC>FGCF?FFGGGF9DGGGGGFGF4GGFFCGEFFGGGFGFCGGC9?FF647DFGCCGCGGFGGCGGGCCGGCEFFGGGGEFFGGFGGGGGFGGGGGGG9FG?GGGGGFFGGGGGGFGGCG9CFGGGGGEGGFGGGGGGFCGGGG<FGGGGGCGDFGGGFGGGGGEGGGGGGGDF9GGGGGGGGGGGGGGEGGGGG=G<GGGCGDGGGCGGGGGGGGGGGGGGF9GG;FG;ADFFGGGG6GGFGFGG@GGGF=GGG7=F:FGGFC76'
+#    line2 = 'KC807175.1_Houston	18379	N	237	tTt+3ataT+3ATATt+3atat+3ataT+3ATAT+3ATAtt+3ataT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATATt+3ataT+3ATAt+3ataT+3ATAT+3ATAt+3atat+3atat+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAt+3atat+3ataT+3ATAT+3ATAT+3ATAt+3atat+3atat+3ataT+3ATAT+3ATATt+3atat+3ataT+3ATAt+3atat+3atat+3ataT+3ATAT+3ATAt+3ataTt+3ataT+3ATAT+3ATAT+3ATAT+3ATAt+3atat+3atat+3ataT+3ATAt+3ataT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATATT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAt+3ataT+3ATAt+3ataT+3ATAt+3ataT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAt+3atat+3ataT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAt+3atat+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATATT+3ATAT+3ATAt+3atat+3ataT+3ATAT+3ATAt+3ataT+3ATAt+3ataT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAt+3ataT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAT+3ATAttT^]T	BFG7AGD9FG@8FFGGD>G>@GGGFFGCGGGG9CGGGGFGGGGGDGECGGGBFGGDGFFGGEGGEGAGGGG?GGGCGEFGFG:GGGGGFGGEGGGDG>EFGGGFGFGGCGGEFGGGGGGGFFG>GGGGCD@GGGG;GFGGG9GGGGGGGGCGGGDFGFGGGGGGFGGGGGGF:GGFGFGFFGFFGGGGGGGACGGGCGCFGGGGGFGGGGGEGGGGGGF7GGGGGGGGGGGGG53CG'
+#    multi_inserts = 'KC807175.1_Houston	354	N	252	ggGGGGGGGGGGGGGGGGGGGggGgggGgggGGgGGGGGGgGGGGGGGGGGGGGGGGGGggggggGggggGGGGGGGGggggggGGgGggGGGgGGggGgGGg+2acGGGGG+1AGGG+3CCCggGGGgGGgggGgGGgGGgGGGGGgGGGGgGGggGGgggGGggGGgGGGGgGGgGgGgGgGGGggGGGgggGgGGGgGgGGGgGGGGGGGGGGGGGGGgGGGggGggGGgGGGGGggGGGGGGgGgGgGGGGGGCgGG	CC3;:7F>F>F?>>.38>2>=GGFCAG5G@GFFGF5FFGFGECG6FDFGDGGCGGGGF?GGGGGGGGGGGG8FFEGG6GGGGGGGCFCGGFGGG@G@FFGFDGG@FAG@GGGGGGGCGGG=FGFGGEF@GFGFFGFGGGGGFDG?GGGF7AGGGGD?GGDGFCGGGGGGGGCFFGGGFCGDGGG6FGGGGGG<FG6GGFFGGGGGFGGGGGG2FFCC4G56GG0GGGGGC8GGGGCGGG4@9GGGGFGC9CG'
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/ngs_mapper/tests/test_samtools.py
+++ b/ngs_mapper/tests/test_samtools.py
@@ -303,15 +303,20 @@ class TestUnitBases(MpileupBase):
         r = self._C( str )
         eq_( list('AACCGGTTNNAA'), r.bases )
 
-    def test_insertdelete( self ):
-        str = 'Ref1	1	A	10	G+2AA-2AA*.G,.....	IIIIIIIIII	]]]]]]]]]]'
+    def test_delete( self ):
+        str = 'Ref1	1	A	10	G-2AA*.G,.....	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
-        eq_( ['G','AA'] + list('*AGAAAAAA'), r.bases )
+        eq_( list('G*AGAAAAAA'), r.bases )
 
     def test_endreadbeginread( self ):
         str = 'Ref1	1	N	10	A^]A$AAAAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( list('AAAAAAAAAA'), r.bases )
+
+    def test_insert(self):
+        str = 'Ref1	1	A	10	G+2AA.G,.....	IIIIIIIIII	]]]]]]]]]]'
+        r = self._C(str)
+        eq_(['GAA'] + list('AGAAAAAA'), r.bases)
 
 class TestUnitBQuals(MpileupBase):
     pass
@@ -449,22 +454,22 @@ class TestUnitPileupColumnInit(MpileupBase):
         eq_( [40]*10, r.bquals )
 
     def test_insert_start( self ):
-        str = 'Ref1	1	N	10	+2NNAAAAAAAAAA	IIIIIIIIII	]]]]]]]]]]'
+        str = 'Ref1	1	N	10	A+2NNAAAAAAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( ['NN'] + list('A'*10), r.bases )
+        eq_( ['ANN'] + list('A'*10), r.bases )
 
     def test_insert_end( self ):
         str = 'Ref1	1	N	10	AAAAAAAAAA+2NN	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( list('A'*10) + ['NN'], r.bases )
+        eq_( list('A'*9) + ['ANN'], r.bases )
 
     def test_insert_middle( self ):
         str = 'Ref1	1	N	10	AAAAA+2NNAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( list('A'*5) + ['NN'] + list('AAAAA'), r.bases )
+        eq_( list('A'*4) + ['ANN'] + list('AAAAA'), r.bases )
 
     def test_delete_start( self ):
         str = 'Ref1	1	N	10	-2NNAAAAAAAAAA	IIIIIIIIII	]]]]]]]]]]'

--- a/ngs_mapper/tests/test_samtools.py
+++ b/ngs_mapper/tests/test_samtools.py
@@ -548,3 +548,13 @@ class TestUnitParseRegionString(Base):
     def test_correct_multibase( self ):
         r = self._C( 'ref:1-2' )
         eq_( ('ref',1,2), r )
+
+
+
+class TesUnitInsertions(Base):
+    pass
+"A$AA+1TA+1TT+1T" == "A-", "A", "AT", "AT", "TT" #order?
+
+#use Counter to get the counts of each afterwards
+"A$AA+1T" == "A-", "A", "AT" #order?
+

--- a/ngs_mapper/tests/test_samtools.py
+++ b/ngs_mapper/tests/test_samtools.py
@@ -78,7 +78,7 @@ Options: -b       output BAM
         eq_( os.stat(self.bam).st_size, os.stat('new.bam').st_size )
 
     def test_regionstring( self ):
-        # Returns all reads for Ref2 since the test sam file 
+        # Returns all reads for Ref2 since the test sam file
         # has reads under every base(reads for ref 2 start at 10 and go to 20
         res = self._C( self.bam, 'Ref2:3-5' )
         i = 0
@@ -296,22 +296,22 @@ class TestUnitBases(MpileupBase):
     def test_lowercaseuppercase( self ):
         str = 'Ref1	1	N	10	AaCcGgTtNn	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
-        eq_( 'AACCGGTTNN', r.bases )
+        eq_( list('AACCGGTTNN'), r.bases )
 
     def test_dotcomma( self ):
         str = 'Ref1	1	A	12	.,CcGgTtNn.,	IIIIIIIIIIII	]]]]]]]]]]]]'
         r = self._C( str )
-        eq_( 'AACCGGTTNNAA', r.bases )
+        eq_( list('AACCGGTTNNAA'), r.bases )
 
     def test_insertdelete( self ):
         str = 'Ref1	1	A	10	G+2AA-2AA*.G,.....	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
-        eq_( 'G*AGAAAAAA', r.bases )
+        eq_( ['G','AA'] + list('*AGAAAAAA'), r.bases )
 
     def test_endreadbeginread( self ):
         str = 'Ref1	1	N	10	A^]A$AAAAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
-        eq_( 'AAAAAAAAAA', r.bases )
+        eq_( list('AAAAAAAAAA'), r.bases )
 
 class TestUnitBQuals(MpileupBase):
     pass
@@ -321,7 +321,7 @@ class TestUnitMQuals(MpileupBase):
         str = 'Ref1	1	N	10	AAAAAAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( [60]*10, r.mquals )
-    
+
     def test_mquals_ne_bquals_len_same( self ):
         str = 'Ref1	1	N	10	AAAAAAAAAA	IIIIIIIIII	]]]]]]]]]]]'
         r = self._C( str )
@@ -445,44 +445,44 @@ class TestUnitPileupColumnInit(MpileupBase):
         str = 'Ref1	1	N	10	AAAAAAAAAA	IIIIIIIIII'
         r = self._C( str )
         eq_( [], r.mquals )
-        eq_( 'A'*10, r.bases )
+        eq_( list('A'*10), r.bases )
         eq_( [40]*10, r.bquals )
 
     def test_insert_start( self ):
         str = 'Ref1	1	N	10	+2NNAAAAAAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( 'A'*10, r.bases )
+        eq_( ['NN'] + list('A'*10), r.bases )
 
     def test_insert_end( self ):
         str = 'Ref1	1	N	10	AAAAAAAAAA+2NN	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( 'A'*10, r.bases )
+        eq_( list('A'*10) + ['NN'], r.bases )
 
     def test_insert_middle( self ):
         str = 'Ref1	1	N	10	AAAAA+2NNAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( 'A'*10, r.bases )
+        eq_( list('A'*5) + ['NN'] + list('AAAAA'), r.bases )
 
     def test_delete_start( self ):
         str = 'Ref1	1	N	10	-2NNAAAAAAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( 'A'*10, r.bases )
+        eq_( list('A'*10), r.bases )
 
     def test_delete_end( self ):
         str = 'Ref1	1	N	10	AAAAAAAAAA-2NN	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( 'A'*10, r.bases )
+        eq_( list('A'*10), r.bases )
 
     def test_delete_middle( self ):
         str = 'Ref1	1	N	10	AAAAA-2NNAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( 'A'*10, r.bases )
+        eq_( list('A'*10), r.bases )
 
     def test_other_characters( self ):
         str = 'Ref1	1	N	10	A$.,aAA^]AA*A	IIIIIIIIII	]]]]]]]]]]'
@@ -490,13 +490,13 @@ class TestUnitPileupColumnInit(MpileupBase):
         eq_( 10, r.depth )
         eq_( 'I'*10, r._bquals )
         eq_( ']'*10, r._mquals )
-        eq_( 'ANNAAAAA*A', r.bases )
+        eq_( list('ANNAAAAA*A'), r.bases )
 
     def test_indel_gt_9( self ):
         str = 'Ref1	1	N	10	AAAAA-10NNNNNNNNNNAAAAA	IIIIIIIIII	]]]]]]]]]]'
         r = self._C( str )
         eq_( 10, r.depth )
-        eq_( 'A'*10, r.bases )
+        eq_( list('A'*10), r.bases )
 
     def test_gap( self ):
         # Guess gaps don't have quality scores
@@ -505,7 +505,7 @@ class TestUnitPileupColumnInit(MpileupBase):
         eq_( 10, r.depth )
         eq_( 'I'*10, r._bquals )
         eq_( ']'*10, r._mquals )
-        eq_( 'A'*10, r.bases )
+        eq_( list('A'*10), r.bases )
 
 class TestUnitParseRegionString(Base):
     functionname = 'parse_regionstring'

--- a/ngs_mapper/tests/test_samtools.py
+++ b/ngs_mapper/tests/test_samtools.py
@@ -7,7 +7,7 @@ from mock import MagicMock, patch, Mock, call
 
 from os.path import *
 import os
-from ngs_mapper.samtools import get_base_list
+from ngs_mapper.samtools import get_base_list, get_gapped_bases
 class Base(common.BaseBaseCaller):
     modulepath = 'ngs_mapper.samtools'
 
@@ -310,22 +310,24 @@ class TestGetBaseList(Base):
         res = sorted(get_base_list("A+1TA+2TAA+2TT", 'C'))
         eq_(sorted(["AT", "ATA", "ATT"]), res) #order?
 
-#    def test_read_end(self):
-#        res = sorted(get_base_list("A$AA+1TA+1TT+1T", 'C'))
-#        eq_(sorted(["A-", "A", "AT", "AT", "TT"]), res) #order?
-#
-##use Counter to get the counts of each afterwards
-#    def test_insertion_read(self):
-#        res = sorted(get_base_list("A$AA+1T", 'C'))
-#        eq_(sorted(["A-", "A", "AT"]), res) #order?
-#
-#    def test_insertion_is_end_of_read_has_no_gap(self):
-#        res = sorted(get_base_list("A+1T$A+2TAA+2TT", 'C'))
-#        eq_(sorted(["AT", "ATA", "ATT"]), res) #order?
-#
-#    def test_insertion_not_end_has_gap(self):
-#        res = sorted(get_base_list("A+1TA+2TAA+2TT", 'C'))
-#        eq_(sorted(["AT-", "ATA", "ATT"]), res) #order?
+class TestGetGappedBases(Base):
+    def test_read_end(self):
+        res = sorted(get_gapped_bases("A$AA+1TA+1TT+1T", 'C'))
+        eq_(sorted(["A-", "A", "AT", "AT", "TT"]), res) #order?
+
+#use Counter to get the counts of each afterwards
+    def test_insertion_read(self):
+        res = sorted(get_gapped_bases("A$AA+1T", 'C'))
+        eq_(sorted(["A-", "A", "AT"]), res) #order?
+
+    def test_insertion_is_end_of_read_has_no_gap(self):
+        res = sorted(get_gapped_bases("A+1T$A+2TAA+2TT", 'C'))
+        eq_(sorted(["AT", "ATA", "ATT"]), res) #order?
+
+    def test_insertion_not_end_has_gap(self):
+        res = sorted(get_gapped_bases("A+1TA+2TAA+2TT", 'C'))
+        eq_(sorted(["AT-", "ATA", "ATT"]), res) #order?
+
 class TestUnitBases(MpileupBase):
 
     def test_lowercaseuppercase( self ):


### PR DESCRIPTION

Closes #166

I can make this a PR against the master branch if that would work better.

Currently base_caller.py tests fail fail at position 2018 of fullsample.bam. There is an insertion here according to samtools tview, but not a 50% supported one, so we need to add logic to the base-caller to skip over it, and add/change tests so that it handles the true insertions correctly.

That position is reported as having DP : 20 but in the pileup I see a depth of 4, wondering what's causing that. Maybe the biasing? 
