### PR TITLE
waffle.io Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://badge.waffle.io/VDBWRAIR/ngs_mapper.png?label=ready&title=Ready 
+ :target: https://waffle.io/VDBWRAIR/ngs_mapper
+ :alt: 'Stories in Ready'
 .. image:: https://readthedocs.org/projects/ngs_mapper/badge/?version=latest
     :target: http://ngs_mapper.readthedocs.org/en/latest/
     :alt: Documentation Status


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/VDBWRAIR/ngs_mapper

This was requested by a real person (user averagehat) on waffle.io, we're not trying to spam you.